### PR TITLE
Include notebook testing to codecov

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,6 +57,8 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest -v --cov=mlcolvar --cov-report=xml --color=yes mlcolvar/tests/
+          pytest --nbmake docs/notebooks/ --ignore=docs/notebooks/tutorials/data/ --cov=mlcolvar --cov-append --cov-report=xml --color=yes 
+
           cat ./coverage.xml
 
       - name: CodeCov

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,7 +57,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest -v --cov=mlcolvar --cov-report=xml --color=yes mlcolvar/tests/
-          pytest --nbmake docs/notebooks/ --ignore=docs/notebooks/tutorials/data/ --cov=mlcolvar --cov-append --cov-report=xml --color=yes 
+          pytest -v --nbmake docs/notebooks/ --ignore=docs/notebooks/tutorials/data/ --cov=mlcolvar --cov-append --cov-report=xml --color=yes 
 
           cat ./coverage.xml
 

--- a/docs/notebooks/tutorials/cvs_DeepTICA.ipynb
+++ b/docs/notebooks/tutorials/cvs_DeepTICA.ipynb
@@ -1218,7 +1218,7 @@
     "\n",
     "# define callbacks\n",
     "metrics = MetricsCallback()\n",
-    "early_stopping = EarlyStopping(monitor=\"valid_loss\", min_delta=1e-4, patience=10)\n",
+    "early_stopping = EarlyStopping(monitor=\"valid_loss\", min_delta=1e-3, patience=10)\n",
     "\n",
     "# define trainer\n",
     "trainer = lightning.Trainer(callbacks=[metrics, early_stopping],\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ numpy
 matplotlib
 lightning
 kdepy
-scikit-learn


### PR DESCRIPTION
## Description
By mistake in #64 we removed the noteboooks testing. Here we add them back to where they belong and include their testing to the code coverage

## Status
- [ ] Ready to go