### PR TITLE
Moved notebook tests only to Ubuntu

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -66,6 +66,7 @@ jobs:
           pytest -v --nbmake docs/notebooks/ --ignore=docs/notebooks/tutorials/data/ --cov=mlcolvar --cov-append --cov-report=xml --color=yes 
 
       - name: CodeCov
+        if: contains( matrix.os, 'ubuntu' )
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,7 +57,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest -v --cov=mlcolvar --cov-report=xml --color=yes mlcolvar/tests/
-          pytest -v --nbmake docs/notebooks/ --ignore=docs/notebooks/tutorials/data/ --cov=mlcolvar --cov-append --cov-report=xml --color=yes 
 
       - name: Run notebook tests
         # conda setup requires this special shell


### PR DESCRIPTION
## Description
In a previous commit there was aa bug in the test list and the notebooks test were runa also outside Ubuntu, leading to cell-time-limit errors sometimes.

## Status
- [ ] Ready to go