### PR TITLE
specify dependency version requirement 

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,7 +19,8 @@ dependencies:
   - numpy
   - pandas
   - pytorch
-  - lightning<=2.0.1
+  - pydantic<2
+  - lightning
   - matplotlib
   - scikit-learn
   - scipy<1.11

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -15,14 +15,15 @@ dependencies:
   - numpy
   - pandas
   - pytorch
-  - lightning<=2.0.1
+  - pydantic<2 # workaround to avoid clashes with lightning
+  - lightning
 
   # utils
   - matplotlib
   - nbsphinx
   - ipython
   - ipykernel
-  - scipy<1.11
+  - scipy<1.11 # latest version does not work with kdepy
 
   # Pip-only installs
   - pip:


### PR DESCRIPTION
pydantic = 2 is not compatible with lightning (see https://github.com/Lightning-AI/lightning/issues/18027) 

this is a workaround to compile docs and CI while a new patch of lightning is released 