### PR TITLE
Fix mamba commands migration issue 

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -42,7 +42,7 @@ jobs:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
           channels: conda-forge,defaults
-          extra-specs: >-
+          create-args: >-
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -36,13 +36,13 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba%60
+      - uses: mamba-org/setup-micromamba@main
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
           channels: conda-forge,defaults
-          extra-specs: |
+          extra-specs: >-
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: conda-forge,defaults
+          # channels: conda-forge,defaults
           create-args: >-
             python=${{ matrix.python-version }}
 


### PR DESCRIPTION
## Description
provision-with-micromamba has been migrated to setup-micromamba so the CI test are not running, see #94  

See https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba%60 for details


## Status
- [x] Ready to go