### PR TITLE
change register_cmap to register

### DIFF
--- a/mlcolvar/utils/plot.py
+++ b/mlcolvar/utils/plot.py
@@ -5,7 +5,8 @@
 
 import mlcolvar
 from matplotlib.colors import LinearSegmentedColormap, ColorConverter
-from matplotlib.cm import register_cmap
+import matplotlib as mpl
+import matplotlib.patches as mpatches
 
 __all__ = ["paletteFessa", "paletteCortina"]
 
@@ -21,8 +22,8 @@ paletteFessa = [
 ]
 
 cm_fessa = LinearSegmentedColormap.from_list("fessa", paletteFessa)
-register_cmap(cmap=cm_fessa)
-register_cmap(cmap=cm_fessa.reversed())
+mpl.colormaps.register(cmap=cm_fessa)
+mpl.colormaps.register(cmap=cm_fessa.reversed())
 
 for i in range(len(paletteFessa)):
     ColorConverter.colors[f"fessa{i}"] = paletteFessa[i]
@@ -49,8 +50,8 @@ paletteCortina = [
 ]
 
 cm_cortina = LinearSegmentedColormap.from_list("cortina80", paletteCortina)
-register_cmap(cmap=cm_cortina)
-register_cmap(cmap=cm_cortina.reversed())
+mpl.colormaps.register(cmap=cm_cortina)
+mpl.colormaps.register(cmap=cm_cortina.reversed())
 
 ##########################################################################
 ## HELPER FUNCTIONS FOR 2D SYSTEMS
@@ -255,7 +256,6 @@ def plot_metrics(
     else:
         return None
 
-
 def test_utils_plot():
     import matplotlib
 
@@ -272,3 +272,4 @@ def test_utils_plot():
     cmap = matplotlib.colors.Colormap("fessa_r", 2)
     cmap = matplotlib.colors.Colormap("cortina80", 2)
     cmap = matplotlib.colors.Colormap("cortina80_r", 2)
+


### PR DESCRIPTION
## Description
register_cmap has been deprecated by matplotlib, changing it as described here:

```
MatplotlibDeprecationWarning: The register_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps.register(name)`` instead.
```