### PR TITLE
Fix bug unrepresented state.

### DIFF
--- a/mlcolvar/core/loss/tda_loss.py
+++ b/mlcolvar/core/loss/tda_loss.py
@@ -156,7 +156,7 @@ def tda_loss(
 
     for i in range(n_states):
         # check which elements belong to class i
-        if not torch.nonzero(labels == i).any():
+        if not (labels == i).any():
             raise ValueError(
                 f"State {i} was not represented in this batch! Either use bigger batch_size or a more equilibrated dataset composition!"
             )


### PR DESCRIPTION
The current check raised an error even if all labels were present if one of the label was only in the first sample of the batch.

## Status
- [x] Ready to go