### PR TITLE
Bug fix in nn.feedforward

### DIFF
--- a/mlcolvar/core/nn/feedforward.py
+++ b/mlcolvar/core/nn/feedforward.py
@@ -94,7 +94,7 @@ class FeedForward(lightning.LightningModule):
                 modules.append(get_activation(activ))
 
             if drop is not None:
-                modules.append(torch.nn.Dropout(p=drop, inplace=True))
+                modules.append(torch.nn.Dropout(p=drop))
 
             if norm:
                 modules.append(torch.nn.BatchNorm1d(layers[i + 1]))

--- a/mlcolvar/cvs/cv.py
+++ b/mlcolvar/cvs/cv.py
@@ -60,7 +60,7 @@ class BaseCV:
     @property
     def example_input_array(self):
         return torch.randn(
-            self.in_features
+            (1,self.in_features)
             if self.preprocessing is None
             or not hasattr(self.preprocessing, "in_features")
             else self.preprocessing.in_features

--- a/mlcolvar/tests/test_core_nn_feedforward.py
+++ b/mlcolvar/tests/test_core_nn_feedforward.py
@@ -101,4 +101,6 @@ def test_feedforward(activation, dropout, batchnorm, last_layer_activation):
     # Test that the forward doesn't explode.
     batch_size = 2
     x = torch.zeros((batch_size, in_features))
-    model(x)
+    out = model(x)
+    # check it can backprop
+    model.backward(out.sum())


### PR DESCRIPTION
## Description
Fix bug of in_place dropout application that makes backprop fail and in batchnorm option, see #118
Also adds a backward call in test for nn.feedforward

## Status
- [x] Ready to go