### PR TITLE
Remove scipy version requirement from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "numpy",
     "pandas",
     "matplotlib",
-    "scipy<1.11.0",
+    "scipy",
     "KDEpy"
 ]
 


### PR DESCRIPTION
The check was removed from ``test_env.yaml`` and ``docs/requirements.yaml`` in #109 but it is still in ``pyproject.toml``

## Status
- [x] Ready to go