### PR TITLE
Test PyPI version via CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -6,11 +6,9 @@ on:
   push:
     branches:
       - "main"
-      - "lightning"
   pull_request:
     branches:
       - "main"
-      - "lightning"
   schedule:
     # Weekly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.
@@ -28,7 +26,7 @@ jobs:
         python-version: [3.8, 3.9, "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,7 +13,7 @@ on:
     # Weekly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.
     #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
-    - cron: "0 0 * * 0"
+    - cron: "0 2 * * 1"
 
 jobs:
   test:

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         # os: [macOS-latest, ubuntu-latest, windows-latest]      # TODO use this when macOS-latest becomes stable again
-        os: [macOS-13, ubuntu-latest, windows-latest]
+        # os: [macOS-13, ubuntu-latest, windows-latest]          # TODO macOS-13 fails when building scipy with pip
         python-version: [3.8, 3.9, "3.10"]
 
     steps:

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -3,7 +3,7 @@ name: PyPI
 on:
   schedule:
     # Weekly tests 
-    - cron: "0 0 * * 0"
+    - cron: "0 2 * * 1"
 
 jobs:
   test:

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         # os: [macOS-latest, ubuntu-latest, windows-latest]      # TODO use this when macOS-latest becomes stable again
         # os: [macOS-13, ubuntu-latest, windows-latest]          # TODO macOS-13 fails when building scipy with pip
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9, "3.10"]
 
     steps:

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # The cookiecutter uses the "--initial-branch" flag when it runs git-init
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    # Weekly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * 0"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # os: [macOS-latest, ubuntu-latest, windows-latest]      # TODO use this when macOS-latest becomes stable again
+        os: [macOS-13, ubuntu-latest, windows-latest]
+        python-version: [3.8, 3.9, "3.10"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout latest tag
+        shell: bash
+        run: |
+          TAG=`git describe --tags $(git rev-list --tags --max-count=1)`
+          git checkout tags/$TAG
+
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
+
+      - name: Install package from PyPI
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          python -m pip install mlcolvar
+          micromamba list
+
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=mlcolvar --cov-report=xml --color=yes mlcolvar/tests/
+
+      - name: Run notebook tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        if: contains( matrix.os, 'ubuntu' )
+        run: |
+          pytest -v --nbmake docs/notebooks/ --ignore=docs/notebooks/tutorials/data/ --cov=mlcolvar --cov-append --cov-report=xml --color=yes 
+
+      - name: CodeCov
+        if: contains( matrix.os, 'ubuntu' )
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: codecov
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -48,7 +48,7 @@ jobs:
         # conda setup requires this special shell
         shell: bash -l {0}
         run: |
-          python -m pip install mlcolvar
+          python -m pip install mlcolvar[test]
           pip list
 
       - name: Run tests

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: PyPI
 
 on:
   # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -1,18 +1,8 @@
 name: PyPI
 
 on:
-  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
-  # The cookiecutter uses the "--initial-branch" flag when it runs git-init
-  push:
-    branches:
-      - "main"
-  pull_request:
-    branches:
-      - "main"
   schedule:
-    # Weekly tests run on main by default:
-    #   Scheduled workflows run on the latest commit on the default or base branch.
-    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    # Weekly tests 
     - cron: "0 0 * * 0"
 
 jobs:

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -34,6 +34,7 @@ jobs:
         shell: bash
         run: |
           TAG=`git describe --tags $(git rev-list --tags --max-count=1)`
+          echo "Latest tag is: $TAG"
           git checkout tags/$TAG
 
       - name: Additional info about the build
@@ -48,7 +49,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install mlcolvar
-          micromamba list
+          pip list
 
       - name: Run tests
         # conda setup requires this special shell

--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -62,12 +62,3 @@ jobs:
         if: contains( matrix.os, 'ubuntu' )
         run: |
           pytest -v --nbmake docs/notebooks/ --ignore=docs/notebooks/tutorials/data/ --cov=mlcolvar --cov-append --cov-report=xml --color=yes 
-
-      - name: CodeCov
-        if: contains( matrix.os, 'ubuntu' )
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: codecov
-          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "lighting" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "lighting"   ]
+    branches: [ "main" ]
   schedule:
-    - cron: "33 10 * * 1"
+    - cron: "0 2 * * 1"
 
 jobs:
   analyze:


### PR DESCRIPTION
## Description
Improve continuos integration via github actions and test also the PyPI version to identify dependency issues as in #143.
Suggested by @andrrizzi  in #144 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] create new workflow for PyPI version
    - [x] Install mlcolvar from pip
    - [x] checkout to latest tag
  - [x] update CI to use latest actions (checkout/v4)

## Status
- [x] Ready to go