### PR TITLE
Add SequentialTransform

### DIFF
--- a/mlcolvar/core/transform/__init__.py
+++ b/mlcolvar/core/transform/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["Transform","Normalization","Statistics","SwitchingFunctions","MultipleDescriptors","PairwiseDistances","EigsAdjMat","ContinuousHistogram","Inverse",'TorsionalAngle']
+__all__ = ["Transform","Normalization","Statistics","SwitchingFunctions","MultipleDescriptors","PairwiseDistances","EigsAdjMat","ContinuousHistogram","Inverse","TorsionalAngle","SequentialTransform"]
 
 from .transform import *
 from .utils import *

--- a/mlcolvar/core/transform/utils.py
+++ b/mlcolvar/core/transform/utils.py
@@ -135,6 +135,9 @@ def test_sequential_transform():
     cont_seq = sequential(pos)
     cont_seq.sum().backward()
     assert(torch.allclose(cont_ref, cont_seq))
+    assert(sequential.in_features == compute_distances.in_features)
+    assert(sequential.out_features == apply_switch.out_features)
+
 
     # check the machinery in training, we use the committor as it applies preprocessing in the training as well
     from mlcolvar.cvs.committor import Committor

--- a/mlcolvar/core/transform/utils.py
+++ b/mlcolvar/core/transform/utils.py
@@ -10,6 +10,10 @@ class SequentialTransform(torch.nn.Sequential):
     @property
     def in_features(self):
       return next(self.modules())[0].in_features
+    
+    @property
+    def out_features(self):
+      return next(self.modules())[-1].out_features
 
 class Inverse(torch.nn.Module):
     "Wrapper to return the inverse method of a module as a torch.nn.Module"

--- a/mlcolvar/core/transform/utils.py
+++ b/mlcolvar/core/transform/utils.py
@@ -2,8 +2,14 @@ import torch
 from typing import Union
 from warnings import warn
 
-__all__ = ["Inverse", "Statistics"]
+__all__ = ["SequentialTransform", "Inverse", "Statistics"]
 
+
+class SequentialTransform(torch.nn.Sequential):
+    "Helper class to apply multiple transforms sequentially working exactly as `torch.nn.Sequential`"
+    @property
+    def in_features(self):
+      return next(self.modules())[0].in_features
 
 class Inverse(torch.nn.Module):
     "Wrapper to return the inverse method of a module as a torch.nn.Module"
@@ -102,6 +108,54 @@ class Statistics(object):
             repr += f"{prop}: {getattr(self,prop).numpy()} "
         return repr
     
+def test_sequential_transform():
+    # test with sequential PairwiseDistances and a SwitchingFunctions as to compute contacts
+    from mlcolvar.core.transform.descriptors import PairwiseDistances
+    from mlcolvar.core.transform.tools import SwitchingFunctions
+    
+    compute_distances = PairwiseDistances(n_atoms=4, PBC=True, cell=[2,2,2], scaled_coords=True)
+    apply_switch = SwitchingFunctions(in_features=6, name='Rational', cutoff=1)
+
+    # mock positions
+    pos = torch.rand((2, 4, 3))
+    pos.requires_grad = True
+
+    # create sequential transform
+    sequential = SequentialTransform(compute_distances, apply_switch)
+
+    # compute reference
+    dist = compute_distances(pos)
+    cont_ref = apply_switch(dist)
+
+    # compute sequential
+    cont_seq = sequential(pos)
+    cont_seq.sum().backward()
+    assert(torch.allclose(cont_ref, cont_seq))
+
+    # check the machinery in training, we use the committor as it applies preprocessing in the training as well
+    from mlcolvar.cvs.committor import Committor
+    from mlcolvar.cvs.committor.utils import initialize_committor_masses
+    from mlcolvar.data import DictDataset, DictModule
+    import lightning
+
+    masses = initialize_committor_masses(atom_types=[0,0,0,0], masses=[1.008])
+    model = Committor(layers=[6,2,1], mass=masses, alpha=1)
+    model.preprocessing = sequential
+
+    pos = torch.rand((5, 4, 3))
+    labels = torch.zeros(len(pos))
+    labels[int(len(pos)/2):] += 1
+    weights = torch.ones(len(pos))
+
+    dataset = DictDataset({"data": pos, "labels": labels, "weights": weights})
+    datamodule = DictModule(dataset, lengths=[1])
+
+    # train model
+    trainer = lightning.Trainer(max_epochs=5, logger=None, enable_checkpointing=False, limit_val_batches=0, num_sanity_val_steps=0)
+    trainer.fit(model, datamodule)
+
+    out = model(pos)
+    out.sum().backward()
 
 def test_inverse():
     from mlcolvar.core.transform import Transform
@@ -176,5 +230,6 @@ def test_statistics():
 
 
 if __name__ == "__main__":
+    test_sequential_transform()
     test_inverse()
     test_statistics()

--- a/mlcolvar/cvs/committor/committor.py
+++ b/mlcolvar/cvs/committor/committor.py
@@ -98,6 +98,8 @@ class Committor(BaseCV, lightning.LightningModule):
         """Compute and return the training loss and record metrics."""
         # =================get data===================
         x = train_batch["data"]
+        # check data are have shape (n_data, -1)
+        x = x.reshape((x.shape[0], -1))
         x.requires_grad = True
 
         labels = train_batch["labels"]

--- a/mlcolvar/tests/test_core_transform_utils.py
+++ b/mlcolvar/tests/test_core_transform_utils.py
@@ -1,5 +1,6 @@
-from mlcolvar.core.transform.utils import test_inverse, test_statistics
+from mlcolvar.core.transform.utils import test_inverse, test_statistics, test_sequential_transform
 
 if __name__ == "__main__":
     test_inverse()
     test_statistics()
+    test_sequential_transform()


### PR DESCRIPTION
## Description
This PR adds a `SequentialTransform` helper class that allows combining multiple trasforms in a sequential way to fix #140.
The new class works exactly like `torch.nn.Sequential` but also has `in_features` and `out_features` attributes.

## Status
- [x] Ready to go