### PR TITLE
Numpy 2 update temporary fixes

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]      # TODO use this when macOS-latest becomes stable again
-        # os: [macOS-13, ubuntu-latest, windows-latest]
+        # os: [macOS-latest, ubuntu-latest, windows-latest]      # TODO use this when macOS-latest becomes stable again
+        os: [macOS-13, ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9, "3.10"]
 
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [macOS-latest, ubuntu-latest, windows-latest]      # TODO use this when macOS-latest becomes stable again
-        os: [macOS-13, ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-latest, windows-latest]      # TODO use this when macOS-latest becomes stable again
+        # os: [macOS-13, ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9, "3.10"]
 
     steps:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,7 +16,7 @@ dependencies:
   - codecov
 
     # Package dependencies
-  - numpy
+  - numpy<2
   - pandas
   - pytorch
   - pydantic<2

--- a/mlcolvar/utils/fes.py
+++ b/mlcolvar/utils/fes.py
@@ -180,7 +180,7 @@ def compute_fes(
                 (X[:, i].min() - offset, X[:, i].max() + offset) for i in range(dim)
             ]
         grid_list = [np.linspace(b[0], b[1], num_samples) for b in bounds]
-        grid = np.meshgrid(*grid_list)
+        grid = list(np.meshgrid(*grid_list))
         positions = np.vstack([g.ravel() for g in grid]).T
 
     # divide in blocks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 lightning
 torch
-numpy
+numpy<2
 pandas
 matplotlib
 kdepy


### PR DESCRIPTION
## Description
After Numpy's new releases, a few bugs appeared that are related to Numpy and its interaction with Pytorch.
After a couple of weeks they still have not been fixed, the tests are failing and the installation is then unstable.
A temporary fixed should be done. 
This sets numpy<2 in the requirements for now because on macos numpy>2 just doesn't work with pytorch yet.

Also, it fixes preventively this silly issue related to Numpy>2
- `np.meshgrid` output from list to tuple made `compute_fes` crash

Questions
- [ ] Is it ok to keep numpy<2 and open an issue to check in the future if the problem is fixed?

## Status
- [ ] Ready to go