### PR TITLE
add config file to readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ import mlcolvar
 # -- Project information -----------------------------------------------------
 
 project = 'mlcolvar'
-copyright = ("2023, Luigi Bonati et. al.")
+copyright = ("2023-present, Luigi Bonati et. al.")
 author = 'Luigi Bonati'
 
 # The short X.Y version

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -12,5 +12,8 @@ python:
     - method: pip
       path: .
 
+sphinx:
+  configuration: docs/conf.py
+
 conda:
   environment: docs/requirements.yaml


### PR DESCRIPTION
## Description
Add config file to readthedocs.yaml, as it is now mandatory:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/