### PR TITLE
Add optional noise to positions in smart derivatives utils

### DIFF
--- a/mlcolvar/cvs/committor/utils.py
+++ b/mlcolvar/cvs/committor/utils.py
@@ -136,7 +136,8 @@ def get_descriptors_and_derivatives(dataset,
                                  n_atoms : int, 
                                  separate_boundary_dataset=True, 
                                  setup_device='cpu',
-                                 force_all_atoms : bool = False):
+                                 force_all_atoms : bool = False,
+                                 positions_noise : float = 0.0):
     """Wrapper function to setup a faster calculation of derivatives computing only once the derivatives of descriptors wrt positions.
 
     Parameters
@@ -151,8 +152,12 @@ def get_descriptors_and_derivatives(dataset,
         Switch to exculde boundary condition labeled data from the variational loss, by default True
     setup_device : str, optional
         Device on which to perform the expensive calculations. Either 'cpu' or 'cuda', by default 'cpu'
-    force_all_atoms: bool
+    force_all_atoms : bool
         Whether to allow the use in SmartDerivatives of atoms that are non involved in the calculation of any descriptor, by default False
+    positions_noise : float
+        Order of magnitude of small noise to be added to the positions to avoid atoms having the exact same coordinates on some dimension and thus zero derivatives, by default 0.
+        Ideally the smaller the better, e.g., 1e-6 for single precision, even lower for double precision.
+
     Returns
     -------
     smart_derivatives : torch.nn.Module
@@ -160,11 +165,13 @@ def get_descriptors_and_derivatives(dataset,
     smart_dataset : DictDataset
         Updated dataset. Dataset['data'] are the computed descriptors
     """
+
     # apply preprocessing and compute derivatives of descriptors
     pos, desc, d_desc_d_x = compute_descriptors_derivatives(dataset=dataset, 
                                                             descriptor_function=descriptor_function, 
                                                             n_atoms=n_atoms, 
-                                                            separate_boundary_dataset=separate_boundary_dataset)
+                                                            separate_boundary_dataset=separate_boundary_dataset,
+                                                            positions_noise=positions_noise)
 
   # this sets up the fixed part of the calculation of the derivatives
     smart_derivatives = SmartDerivatives(d_desc_d_x, 


### PR DESCRIPTION
## Description
To fix a bug in smart derivatives related to some descriptors having some zero component of the derivatives (see also #176) I added the option of adding a small noise to the positions in the smart derivatives utils:
- `mlcolvar.core.loss.committor_loss.compute_descriptors_derivatives`
- `mlcolvar.cvs.committor.utils.get_descriptors_and_derivatives`

The default behaviour is unchanged but if the bug is encountered it throws an error pointing to the new option.

This fixes #176