### PR TITLE
feat: Take into account device of input tensor

### DIFF
--- a/mlcolvar/core/transform/utils.py
+++ b/mlcolvar/core/transform/utils.py
@@ -78,7 +78,7 @@ class Statistics(object):
         # Initialize
         if self.mean is None:
             for prop in ["mean", "M2", "std"]:
-                setattr(self, prop, torch.zeros(nfeatures))
+                setattr(self, prop, torch.zeros(nfeatures, device=x.device))
 
         # compute sample mean
         sample_mean = torch.mean(x, dim=0)


### PR DESCRIPTION
Recently I came across a problem when trying to compute the statistics of a tensor that was located on the gpu (a tensor with device = cuda). See the last line of the Traceback:

```
  File "/home/pnavarro/repos/mlcolvar/mlcolvar/core/transform/utils.py", line 92, in update
    delta = sample_mean - self.mean
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

The error was due to the input tensor for the Statistics class (from which sample_mean is computed) being located on the cuda device, while the self.mean attribute was initialized with torch.zeros(nfeatures) in the cpu device.

I think initializing the attributes in the same device as the input tensor will be more robust. In my case this fixed the error.

Thank you for all the work you have put into this library by the way. I have found it really useful :)
