### PR TITLE
feat: added beta factor support in VAE CV

### DIFF
--- a/mlcolvar/core/loss/elbo.py
+++ b/mlcolvar/core/loss/elbo.py
@@ -40,6 +40,8 @@ class ELBOGaussiansLoss(torch.nn.Module):
         output: torch.Tensor,
         mean: torch.Tensor,
         log_variance: torch.Tensor,
+        beta: float = 1.0,
+        return_loss_terms: bool = False,
         weights: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Compute the value of the loss function.
@@ -57,6 +59,17 @@ class ELBOGaussiansLoss(torch.nn.Module):
         log_variance : torch.Tensor
             Shape ``(n_batches, latent_features)``. The logarithm of the variances
             of the Gaussian distributions associated to the inputs.
+        beta : float, optional
+            A scaling factor for the KL divergence term. The default is 1.0,
+            which means that the KL divergence is not scaled. If set to a value
+            greater than 1, it will increase the weight of the KL divergence
+            term in the loss function (useful to increase regularization). 
+            If set to a value less than 1, it will decrease the weight
+            of the KL divergence term (useful to avoid posterior collapse)
+        return_loss_terms : bool, optional
+            If ``True``, besides to total loss, return the two main terms of the ELBO
+            separately (reconstruction loss and KL divergence). The default is
+            ``False``, which returns just the total loss.
         weights : torch.Tensor, optional
             Shape ``(n_batches,)`` or ``(n_batches,1)``. If given, the average over
             batches is weighted. The default (``None``) is unweighted.
@@ -66,7 +79,7 @@ class ELBOGaussiansLoss(torch.nn.Module):
         loss: torch.Tensor
             The value of the loss function.
         """
-        return elbo_gaussians_loss(target, output, mean, log_variance, weights)
+        return elbo_gaussians_loss(target, output, mean, log_variance, beta, return_loss_terms, weights)
 
 
 def elbo_gaussians_loss(
@@ -74,6 +87,8 @@ def elbo_gaussians_loss(
     output: torch.Tensor,
     mean: torch.Tensor,
     log_variance: torch.Tensor,
+    beta: float = 1.0,
+    return_loss_terms: bool = False,
     weights: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """ELBO loss function assuming the latent and reconstruction distributions are Gaussian.
@@ -96,6 +111,17 @@ def elbo_gaussians_loss(
     log_variance : torch.Tensor
         Shape ``(n_batches, latent_features)``. The logarithm of the variances
         of the Gaussian distributions associated to the inputs.
+    beta : float, optional
+        A scaling factor for the KL divergence term. The default is 1.0,
+        which means that the KL divergence is not scaled. If set to a value
+        greater than 1, it will increase the weight of the KL divergence
+        term in the loss function (useful to increase regularization). 
+        If set to a value less than 1, it will decrease the weight
+        of the KL divergence term (useful to avoid posterior collapse).
+    return_loss_terms : bool, optional
+        If ``True``, besides to total loss, return the two main terms of the ELBO
+        separately (reconstruction loss and KL divergence). The default is
+        ``False``, which returns just the total loss.
     weights : torch.Tensor, optional
         Shape ``(n_batches,)`` or ``(n_batches,1)``. If given, the average over
         batches is weighted. The default (``None``) is unweighted.
@@ -123,4 +149,9 @@ def elbo_gaussians_loss(
     # Reconstruction loss.
     reconstruction = mse_loss(output, target, weights=weights)
 
-    return reconstruction + kl
+    loss = reconstruction + beta*kl
+    
+    if return_loss_terms:
+        return loss, reconstruction, kl
+    else:
+        return loss

--- a/mlcolvar/cvs/unsupervised/vae.py
+++ b/mlcolvar/cvs/unsupervised/vae.py
@@ -34,8 +34,10 @@ class VariationalAutoEncoderCV(BaseCV, lightning.LightningModule):
     At training time, the encoder outputs a mean and a variance for each CV
     defining a Gaussian distribution associated to the input. One sample is
     drawn from this Gaussian, and it goes through the decoder. Then the ELBO
-    loss is minimized. The ELBO sums the MSE of the reconstruction and the KL
-    divergence between the generated Gaussian and a N(0, 1) Gaussian.
+    loss is minimized [1]_. The ELBO sums the MSE of the reconstruction and the KL
+    divergence between the generated Gaussian and a N(0, 1) Gaussian multiplied
+    by a beta factor. The beta factor can be used to control the weight of the KL
+    divergence term in the loss function [2]_.
 
     At evaluation time, the encoder's output mean is used as the CV, while the
     variance output and the decoder are ignored.
@@ -43,13 +45,17 @@ class VariationalAutoEncoderCV(BaseCV, lightning.LightningModule):
     **Data**: for training, it requires a DictDataset with the key ``'data'`` and
     optionally ``'weights'``. If a 'target' key is present this will be used as reference
     for the output of the decoder, otherway this will be compared with the input 'data'.
-    This feature can be used to train (variational) time-lagged autoencoders like in [1]_.
+    This feature can be used to train (variational) time-lagged autoencoders like in [3]_.
 
     **Loss**: Evidence Lower BOund (ELBO)
 
     References
     ----------
-    .. [1] C. X. Hernández, H. K. Wayment-Steele, M. M. Sultan, B. E. Husic, and V. S. Pande,
+    .. [1] Kingma, Diederik P., and Max Welling. "Auto-encoding variational bayes." 20 Dec. 2013.
+    .. [2] Higgins, Irina, Loic Matthey, Arka Pal, Christopher Burgess, Xavier Glorot, Matthew Botvinick, 
+           Shakir Mohamed, and Alexander Lerchner. “β-VAE: Learning basic visual concepts with a constrained 
+           variational framework.” International Conference on Learning Representations (ICLR), 2017.
+    .. [3] C. X. Hernández, H. K. Wayment-Steele, M. M. Sultan, B. E. Husic, and V. S. Pande,
         “Variational encoding of complex dynamics,” Physical Review E 97, 062412 (2018).
 
     See also
@@ -65,6 +71,7 @@ class VariationalAutoEncoderCV(BaseCV, lightning.LightningModule):
         n_cvs: int,
         encoder_layers: list,
         decoder_layers: Optional[list] = None,
+        beta: float = 1.0,
         options: Optional[dict] = None,
         **kwargs,
     ):
@@ -84,6 +91,8 @@ class VariationalAutoEncoderCV(BaseCV, lightning.LightningModule):
             Number of neurons per layer of the decoder, except for the input layer
             which is specified by ``n_cvs``. If ``None`` (default), it takes automatically
             the reversed architecture of the encoder.
+        beta : float, optional
+            A scaling factor for the KL divergence term in the loss function. The default is 1.0.
         options : dict[str, Any], optional
             Options for the building blocks of the model, by default ``None``.
             Available blocks are: ``'norm_in'``, ``'encoder'``, and ``'decoder'``.
@@ -95,6 +104,7 @@ class VariationalAutoEncoderCV(BaseCV, lightning.LightningModule):
         # =======   LOSS  =======
         # ELBO loss function when latent space and reconstruction distributions are Gaussians.
         self.loss_fn = ELBOGaussiansLoss()
+        self.beta = beta
 
         # ======= OPTIONS =======
         # parse and sanitize
@@ -224,11 +234,20 @@ class VariationalAutoEncoderCV(BaseCV, lightning.LightningModule):
             x_ref = x
 
         # Loss function.
-        loss = self.loss_fn(x_ref, x_hat, mean, log_variance, **loss_kwargs)
+        loss, reconstruction_loss, kl_loss = self.loss_fn(target = x_ref, 
+                                                          output = x_hat, 
+                                                          mean = mean, 
+                                                          log_variance = log_variance, 
+                                                          beta = self.beta,
+                                                          return_loss_terms = True, 
+                                                          **loss_kwargs)
 
         # Log.
         name = "train" if self.training else "valid"
         self.log(f"{name}_loss", loss, on_epoch=True)
+        self.log(f"{name}_reconstruction_loss", reconstruction_loss, on_epoch=True)
+        self.log(f"{name}_kl_loss", kl_loss, on_epoch=True)
+        self.log(f"beta", self.beta, on_epoch=True)
 
         return loss
 


### PR DESCRIPTION
I was trying to use the VAE CV as it is on my dataset (features from an MD simulation). I quickly noticed that my results were not as nice as in the example in the docs. Even using the same activation function and a small decoder as in the example (mlcolvar/docs/notebooks/tutorials/cvs_Autoencoder.ipynb). I was just observing a "blob" of points without any separation of metastable states:

![image](https://github.com/user-attachments/assets/5022fc25-262e-477a-b26a-f2370fe71c9a)

See PCA on the same data for comparison:

![image](https://github.com/user-attachments/assets/f91625c2-4d5b-4d5f-88dd-113163000636)

With a bit of help from my favorite AI buddy (I'm not an expert on Deep learning or VAEs) I believe I identified the main issue. The regularization term in the loss together with my choice of hyperparameters and arquitecture were collapsing the latent space to the prior P(z) ~ N(0,I). So the model learned to reduce the loss just by reducing the KL term and mostly ignored the reconstruction term:

![image](https://github.com/user-attachments/assets/b626b2a0-3916-4d91-90b5-fea5ed8c3e0f)

Before adding the beta factor I tried different arquitecture and hyperparameter choices. What improved the situation in the end was adding a low beta factor (0.001 in this case):

![image](https://github.com/user-attachments/assets/587cb337-31ab-4b5e-b845-3b46277e446e)

From what I understand, introducing a  beta factor to reduce the KL divergence term in the loss function can make the VAE training more robust to the architecture and hyper-parameter choices. Now I'm trying to use a Lightning callback during training to increase the beta factor after some epochs (see below):

```
import lightning

class KLAAnnealing(lightning.Callback):
    """
    Callback to anneal the KL divergence weight (beta).
    
    This callback linearly increases the beta value from 0 to max_beta
    over a specified number of epochs, starting from a given epoch.
    
    Inputs
    ------
    
    max_beta: 
        The final beta value to reach at the end of annealing.
    start_epoch: 
        The epoch at which to start annealing.
    n_epochs_anneal: 
        The number of epochs over which to anneal beta.
    """
    def __init__(self, max_beta=1.0, start_epoch=0, n_epochs_anneal=100):
        super().__init__()
        # The final beta value you want to reach
        self.max_beta = max_beta
        self.start_epoch = start_epoch
        self.n_epochs_anneal = n_epochs_anneal

    def on_train_epoch_start(self, trainer, pl_module):
        current_epoch = trainer.current_epoch
        if current_epoch < self.start_epoch:
            beta = 0.0
        elif current_epoch >= self.start_epoch + self.n_epochs_anneal:
            beta = self.max_beta
        else:
            # Linearly increase beta
            progress = (current_epoch - self.start_epoch) / self.n_epochs_anneal
            beta = self.max_beta * progress
            
        # Set beta in the LightningModule
        # Assumes your pytorch_lightning module has a beta attribute
        if not hasattr(pl_module, 'beta'):
            logger.warning("The LightningModule does not have a 'beta' attribute. "
                           "Please ensure it is defined to use KLAAnnealing.")
            return
        pl_module.beta = beta
        pl_module.log('beta', beta, on_step=False, on_epoch=True)
```
One has to add this callback to the Trainer and beta factor will be modified accordingly:

![image](https://github.com/user-attachments/assets/65a2ee99-59a4-4f4a-af50-dc8f27cffddd)

This beta factor can also be used to obtain disentangled components in the latent space by collapsing the uninformative ones.  See [1]

[1] Burgess, Christopher P., Irina Higgins, Arka Pal, Loic Matthey, Nick Watters, Guillaume Desjardins, and Alexander Lerchner. “Understanding Disentangling in $β$-VAE.” arXiv, April 10, 2018. https://doi.org/10.48550/arXiv.1804.03599.