### PR TITLE
fix: improve vae stability by controlling the minimum std that can be learned

### DIFF
--- a/mlcolvar/cvs/unsupervised/vae.py
+++ b/mlcolvar/cvs/unsupervised/vae.py
@@ -193,9 +193,12 @@ class VariationalAutoEncoderCV(BaseCV, lightning.LightningModule):
         x = self.encoder(x)
         mean, log_variance = self.mean_nn(x), self.log_var_nn(x)
 
+        # Clamp the log_variance to prevent it from becoming -inf (numerical stability).
+        log_variance = torch.clamp(log_variance, min=-15)
+        
         # Sample from the Gaussian distribution in latent space.
         std = torch.exp(log_variance / 2)
-        z = torch.distributions.Normal(mean, std).rsample()
+        z = torch.distributions.Normal(mean, std+1e-8).rsample()
 
         # Decode sample.
         x_hat = self.decoder(z)


### PR DESCRIPTION
For some datasets I obtained the following error: 

```
VAE training failed. Error message: Expected parameter scale (Tensor of shape (128, 2)) of distribution Normal(loc: torch.Size([128, 2]), scale: torch.Size([128, 2])) to satisfy the constraint GreaterThan(lower_bound=0.0), but found invalid values:
tensor([[3.5159e-08, 2.5230e-08],
        [1.7620e-23, 3.2989e-25],
        [6.6246e-12, 2.3463e-10],
        [9.5324e-04, 3.7065e-03],
...
```

This is related to the scale parameter of torch.distributions.Normal being too small. To improve numerical stability during training I think it's a common practice to limit the minimum std that can be learned through torch.clamp().

A minimum of -15 in the log variance would be a minimum value of 1e-15 in the std.

With this modification the instability is gone :) 