### PR TITLE
Avoid deprecated x.T usage in compute_average function

### DIFF
--- a/mlcolvar/core/stats/utils.py
+++ b/mlcolvar/core/stats/utils.py
@@ -221,6 +221,6 @@ def compute_average(x, w=None):
     if w is not None:
         ave = torch.einsum("ij,i ->j", x, w) / torch.sum(w)
     else:
-        ave = torch.mean(x.T, 1, keepdim=False).T
+        ave = torch.mean(x, dim=0)
 
     return ave


### PR DESCRIPTION
## Description
The unweighted branch of compute_average previously relied on x.T, which triggers a PyTorch 1.13+ warning for tensors with ndim != 2.This PR replaces it with torch.mean(x, dim=0).

## Related Issue
Related to #231