### PR TITLE
Support multi-trajectory datasets in create_timelagged_dataset

### DIFF
--- a/mlcolvar/utils/timelagged.py
+++ b/mlcolvar/utils/timelagged.py
@@ -242,6 +242,7 @@ def create_timelagged_dataset(
         Display progress bar with tqdm
     walker : array-like, optional
         Identifier of the trajectory (walker) to which each configuration belongs.
+        This can only be used when `reweight_mode` is set to `weights_t`. 
 
     Returns
     -------
@@ -281,7 +282,16 @@ def create_timelagged_dataset(
             raise ValueError(
                 f"The length of t ({len(t)}) is different from the one of X ({len(X)}) "
             )
-
+    if walker is not None:
+        if reweight_mode == "rescale_time":
+            raise ValueError(
+                "The `walker` argument is not compatible with `reweight_mode='rescale_time'`."
+            )
+        if len(walker) != len(X):
+            raise ValueError(
+                f"The length of walker ({len(walker)}) is different from the one of X ({len(X)}) "
+            )
+        
     # define tprime if not given:
     if reweight_mode == "rescale_time":
         if tprime is None:


### PR DESCRIPTION
## Description
This PR adds optional support for a `walker ` identifier in `create_timelagged_dataset`, ensuring that create_timelagged_dataset is constructed only within the same trajectory when working with multi-walker or replica-based simulations.

Notably, when using the `rescale_time` reweighting mode, the `walker` argument is not required, as configurations from different replicas are already separated in the rescaled time coordinate.

## Status
- [ ] Ready to go