### PR TITLE
Graph node sensitivity for truncated graphs

### DIFF
--- a/mlcolvar/data/graph/utils.py
+++ b/mlcolvar/data/graph/utils.py
@@ -156,8 +156,10 @@ def create_dataset_from_configurations(config: atomic.Configurations,
         restricting the neighborhood to a subsystem (i.e., system + environment), 
         `see also mlcolvar.data.grap.neighborhood.get_neighborhood`
     long_range_cutoff : float
-            Cutoff radius for the long-range edges defined on subsystem atoms. 
-            If negative, no long-range interactions are considered, by default -1.0
+        Cutoff radius for the long-range edges defined on subsystem atoms. 
+        If negative, no long-range interactions are considered, by default -1.0
+    atom_names, List[str]
+        Names of the system atoms. If using truncated graphs, use the system atoms only
     remove_isolated_nodes: bool
         If to remove isolated nodes from the dataset
     show_progress: bool
@@ -167,7 +169,6 @@ def create_dataset_from_configurations(config: atomic.Configurations,
         items = pbar(config, frequency=0.0001, prefix='Making graphs')
     else:
         items = config
-    
     # create a list of torch_geometric data objects, one for each configuration
     data_list = [ _create_pyg_data_from_configuration(config=c, 
                                                       atomic_numbers=atomic_numbers, 
@@ -176,12 +177,14 @@ def create_dataset_from_configurations(config: atomic.Configurations,
                                                       long_range_cutoff=long_range_cutoff,
                                                      ) for c in items
                 ]
+    try:
+        truncated = True if any([c.environment.any() for c in items]) else False
+    except AttributeError:
+        truncated = True if any([c.environment for c in items]) else False
 
     # get atom names if needed
     if atom_names is None:
-        atom_names_system = [f"X{i}" for i in range(data_list[0]['n_system'].to(torch.int64).item())]
-        atom_names_env    = [f"Y{i}" for i in range(data_list[0]['n_env'].to(torch.int64).item())]
-        atom_names        = atom_names_system + atom_names_env
+        atom_names = [f"X{i}" for i in range(data_list[0]['n_system'].to(torch.int64).item())]
 
 
     if remove_isolated_nodes:
@@ -191,7 +194,8 @@ def create_dataset_from_configurations(config: atomic.Configurations,
         # So here we first have to remove the isolated nodes and then set the cell back.
         
         # this aux var is only to check what isolated nodes have been removed
-        _aux_pos = torch.Tensor((np.array([d['positions'].numpy() for d in data_list])))
+        _pre_remove_nodes_pos = torch.Tensor(np.array([d['positions'].numpy() for d in data_list]))
+        _pre_remove_nodes_system_masks = np.array([d['system_masks'].numpy() for d in data_list], dtype=bool)
         
         cell_list = [d.cell.clone() for d in data_list]
         transform = _RemoveIsolatedNodes()
@@ -203,12 +207,13 @@ def create_dataset_from_configurations(config: atomic.Configurations,
             data_list[i].cell = cell_list[i]
 
             # get and save the original index before removing isolated nodes for each entry
-            original_idx = torch.unique( torch.where(torch.isin(torch.round(_aux_pos[i], decimals=5), 
-                                                                torch.round(data_list[i]['positions'], decimals=5))
+            # we slice by the system mask as we don't care about environment atoms
+            original_idx = torch.unique( torch.where(torch.isin(torch.round(_pre_remove_nodes_pos[i][_pre_remove_nodes_system_masks[i].squeeze(), :], decimals=5), 
+                                                                torch.round(data_list[i]['positions'][data_list[i]['system_masks'].squeeze(), :], decimals=5))
                                                     )[0]
                                         )
             
-            data_list[i]['names_idx'] = original_idx.to(torch.int64)
+            data_list[i]['system_names_idx'] = original_idx.to(torch.int64)
             
             # update if needed the overall list
             check = np.isin(original_idx.numpy(), unique_idx, invert=True)
@@ -219,15 +224,15 @@ def create_dataset_from_configurations(config: atomic.Configurations,
         unique_idx.sort()
         unique_idx = torch.Tensor(unique_idx).to(torch.int64)
     
-    # if not remove_isolated_nodes we simply take all the atoms
-    # TODO this needs to be fixed for the variable size of the environment
+    # if not remove_isolated_nodes we simply take all the system atoms
     else:
-        unique_idx = torch.arange(data_list[0]['n_system'].item() + data_list[0]['n_env'].item()).to(torch.int64)
+        unique_idx = torch.arange(data_list[0]['n_system'].item()).to(torch.int64)
         for i in range(len(data_list)):
-            data_list[i]['names_idx'] = unique_idx
+            data_list[i]['system_names_idx'] = unique_idx
     
-    # we also save the names of the atoms that have been actually used
-    unique_names = np.array(atom_names)[unique_idx]
+    # we also save the names of the atoms that have been actually used, ensuring correct dimensions
+
+    unique_names = np.array(atom_names)[unique_idx] if len(unique_idx) > 1 else np.array(np.array(atom_names)[unique_idx])
     unique_names = unique_names.tolist()
 
     dataset = DictDataset(dictionary={'data_list': data_list},
@@ -235,8 +240,9 @@ def create_dataset_from_configurations(config: atomic.Configurations,
                                     'cutoff': cutoff,
                                     'buffer': buffer,
                                     'long_range_cutoff': long_range_cutoff,
-                                    'used_idx': unique_idx,
-                                    'used_names': unique_names},
+                                    'system_idx': unique_idx,
+                                    'system_atoms_names': unique_names,
+                                    'is_truncated_graph': truncated},
                           data_type='graphs')
 
     return dataset

--- a/mlcolvar/data/utils.py
+++ b/mlcolvar/data/utils.py
@@ -65,6 +65,8 @@ def save_dataset_configurations_as_extyz(dataset: DictDataset,
             if extra_key_value.shape[0] != len(dataset['data_list'][0]['positions']) or extra_key_value.shape[-1] != 1:
                 raise ValueError(f"The selected extra_key {key} is not a single per-atom quantity!")
             extra_keys_string = extra_keys_string + f':{key}:R:{extra_key_value.shape[-1]}'
+    else:
+        extra_keys = []
     
     # initialize the atomic number object
     atomic_numbers = dataset.metadata.get("atomic_numbers", None)

--- a/mlcolvar/data/utils.py
+++ b/mlcolvar/data/utils.py
@@ -1,5 +1,6 @@
 import torch
 import numpy as np
+from typing import List   
 
 from mlcolvar.data import DictDataset
 from mlcolvar.data.graph.atomic import AtomicNumberTable
@@ -36,7 +37,9 @@ def load_dataset(file_name: str) -> DictDataset:
     return dataset
 
 
-def save_dataset_configurations_as_extyz(dataset: DictDataset, file_name: str) -> None:
+def save_dataset_configurations_as_extyz(dataset: DictDataset, 
+                                         file_name: str,
+                                         extra_keys: List[str] = None) -> None:
     """Save a dataset to disk in the extxyz format.
 
     Parameters
@@ -45,12 +48,23 @@ def save_dataset_configurations_as_extyz(dataset: DictDataset, file_name: str) -
         Dataset to be saved with data_type graphs
     file_name: str
         Name of the file to save to
+    extra_keys: list[str]
+        Extra keys of data_list to be printed on the extxyz. 
+        Only single per-atom quantities are allowed.
     """
     # check the dataset type is 'graphs'
     if not dataset.metadata["data_type"] == "graphs":
         raise(
             ValueError("Can only save to extxyz dataset with data_type='graphs'!")
         )
+    
+    extra_keys_string = ''
+    if extra_keys is not None:
+        for key in extra_keys:
+            extra_key_value = dataset['data_list'][0][key]
+            if extra_key_value.shape[0] != len(dataset['data_list'][0]['positions']) or extra_key_value.shape[-1] != 1:
+                raise ValueError(f"The selected extra_key {key} is not a single per-atom quantity!")
+            extra_keys_string = extra_keys_string + f':{key}:R:{extra_key_value.shape[-1]}'
     
     # initialize the atomic number object
     atomic_numbers = dataset.metadata.get("atomic_numbers", None)
@@ -71,7 +85,9 @@ def save_dataset_configurations_as_extyz(dataset: DictDataset, file_name: str) -
         # Lattice, properties, pbc
         line = (
             'Lattice="{:s}" '.format((r'{:.5f} ' * 9).strip())
-            + 'Properties=species:S:1:pos:R:3 pbc="T T T"'
+            + 'Properties=species:S:1:pos:R:3'+
+            extra_keys_string +
+            ' pbc="T T T"'
         )
 
         # cell info
@@ -82,11 +98,15 @@ def save_dataset_configurations_as_extyz(dataset: DictDataset, file_name: str) -
         for j in range(0, len(d['positions'])):
             # chemical symbol
             s = atomic_numbers.index_to_symbol(np.where(d['node_attrs'][j])[0][0])
-            print('{:2s}'.format(s), file=fp, end=' ')
+            print('{:2s}'.format(s), file=fp, end='')
 
             # positions
             positions = [p.item() for p in d['positions'][j]]
-            print('{:10.5f} {:10.5f} {:10.5f}'.format(*positions), file=fp)
+            print(' {:10.5f} {:10.5f} {:10.5f}'.format(*positions), file=fp, end='')
+            for key in extra_keys:
+                print(' {:10.5f}'.format(d[key][j][0]), file=fp, end='')
+            print('', file=fp)
+            
     fp.close()
 
 

--- a/mlcolvar/explain/graph_sensitivity.py
+++ b/mlcolvar/explain/graph_sensitivity.py
@@ -1,23 +1,25 @@
 import numpy as np
 from typing import Dict
 import torch
+import copy
 
 from mlcolvar.data import DictModule
 from mlcolvar.utils.plot import pbar
 from mlcolvar.core.nn import BaseGNN
+from mlcolvar.data.utils import save_dataset_configurations_as_extyz
 
 
 __all__ = ['graph_node_sensitivity']
 
 
-def graph_node_sensitivity(
-    model,
-    dataset,
-    component: int = 0,
-    device: str = 'cpu',
-    batch_size: int = None,
-    show_progress: bool = True
-) -> Dict[str, np.ndarray]:
+def graph_node_sensitivity(model,
+                           dataset,
+                           component: int = 0,
+                           device: str = 'cpu',
+                           batch_size: int = None,
+                           show_progress: bool = True,
+                           extxyz_filename: str = None,
+                          ) -> Dict[str, np.ndarray]:
     """Performs a sensitivity analysis on a GNN-based CV model using
     partial derivatives w.r.t. nodes' positions. 
     This allows us to measure which atom is most important to the CV model.
@@ -25,7 +27,8 @@ def graph_node_sensitivity(
     If system/environment atoms are defined in the input dataset, the average node-sensitivities are returned only
     for the system atom, while a aggregated sensitivities (mean and sum) are returned for environment instead.
     
-    # TODO xyz?
+    Optionally, the results can be printed to an extxyz, where each atom is associated to its sensitivity score
+    so that they can be visualized in a molecular viewer.
 
     Parameters
     ----------
@@ -39,6 +42,9 @@ def graph_node_sensitivity(
         Batch size used for evaluating the CV
     show_progress: bool
         If to show the progress bar
+    extxyz_filename: str
+        If provided, a extxyz file with this name is printed with the positions of the atoms in the graph dataset 
+        with the corresponding sensitivities so that they can be visualized in a molecular viewer.
 
     Returns
     -------
@@ -47,11 +53,11 @@ def graph_node_sensitivity(
           - 'node_labels': names associated to the nodes of the graphs. If truncated graphs are used, only the system atoms
                            are labeled, while the contribution from the environment atoms is aggregated with mean and sum.
           - 'avg_sensitivities': averaged sensititivities over the given dataset. If truncated graphs are used, environment 
-                                 values are aggregated with mean and sum.
+                                 values are aggregated with mean and sum. The results are ordered consistently with the node
+                                 labels, the enviroment values are the last two.
           - 'raw_sensitivities': raw sensitivities per-frame, including the sensitivities relative to each atom. If truncated
                                  graphs are used, the sensitivities wrt different environment atoms (whose number may change
-                                 for different frame) are returned.
-        The quantities are ordered consistently with the node labels.
+                                 for different frame) are returned. The results are ordered as the positions in the dataset.
 
     See also
     --------
@@ -66,7 +72,7 @@ def graph_node_sensitivity(
 
     # make user aware of behaviour for truncated graphs
     if dataset.metadata['is_truncated_graph']:
-        print("The input dataset contains truncated graphs for which system and environment selections are provided. the average node-sensitivities" +
+        print("[NOTE] The input dataset contains truncated graphs for which system and environment selections are provided.\nThe average node-sensitivities" +
              "will be returned only for the system atom, while an aggregated sensitivty is returned for environment instead")
 
     model = model.to(device)
@@ -92,7 +98,15 @@ def graph_node_sensitivity(
     results['avg_sensitivities'] = gradients_norm
     results['raw_sensitivities'] = gradients_components
     
-
+    # save an extxyz file with the atoms in the graph and their sensitivity score
+    if extxyz_filename is not None:
+        updated_dataset = copy.deepcopy(dataset)
+        for i, d in enumerate(updated_dataset['data_list']):
+            d['sensitivities'] = gradients_components[i]
+        save_dataset_configurations_as_extyz(dataset=updated_dataset,
+                                             file_name=extxyz_filename,
+                                             extra_keys=['sensitivities'])
+    
     return results
 
 
@@ -146,14 +160,13 @@ def get_dataset_cv_values(model,
     return np.concatenate(cv_values)
 
 
-def get_dataset_cv_gradients(
-    model,
-    dataset,
-    component: int = 0,
-    batch_size: int = None,
-    show_progress: bool = True,
-    progress_prefix: str = 'Calculating CV gradients'
-) -> np.ndarray:
+def get_dataset_cv_gradients(model,
+                             dataset,
+                             component: int = 0,
+                             batch_size: int = None,
+                             show_progress: bool = True,
+                             progress_prefix: str = 'Calculating CV gradients'
+                            ) -> np.ndarray:
     """Get gradients of a GNN-based CV w.r.t. node positions in a given dataset. 
     The calculation will run on the device where the model is on.
 
@@ -226,19 +239,17 @@ def get_dataset_cv_gradients(
             # system grads are treated individually, env grads are aggragated with sum and mean
             for i,g in enumerate(gradients):
                 # slice the gradients to get the contribution from system and environment atoms
-                system_atoms_grads = g[batch_dict[i]['system_masks'].squeeze()]
-                env_atoms_grads    = g[torch.logical_not(batch_dict[i]['system_masks'].squeeze())]
+                system_atoms_grads = torch.linalg.vector_norm( g[batch_dict[i]['system_masks'].squeeze()], dim=-1)
+                env_atoms_grads    = torch.linalg.vector_norm( g[torch.logical_not(batch_dict[i]['system_masks'].squeeze())], dim=-1)
 
                 # add the values to the result lists
-                # one with the components of the gradients of all atoms, system atoms first
-                cv_value_gradients_components.append(torch.vstack([system_atoms_grads, 
-                                                                   env_atoms_grads
-                                                                  ]).cpu().numpy())
+                # one with the components of the gradients of all atoms, ordered as the positions in the dataset
+                cv_value_gradients_components.append(torch.linalg.vector_norm( g, dim=-1).unsqueeze(-1))    
 
                 # one with the norm of the gradients for each system atom and aggregated env atoms
-                cv_value_gradients.extend(torch.concat([torch.linalg.vector_norm(system_atoms_grads, dim=-1),
-                                                        torch.linalg.vector_norm(env_atoms_grads, dim=-1).mean(dim=-1, keepdim=True), 
-                                                        torch.linalg.vector_norm(env_atoms_grads, dim=-1).sum(dim=-1, keepdim=True)
+                cv_value_gradients.extend(torch.concat([system_atoms_grads,
+                                                        env_atoms_grads.mean(dim=-1, keepdim=True), 
+                                                        env_atoms_grads.sum(dim=-1, keepdim=True)
                                                         ]).unsqueeze(0).cpu().numpy()
                                         )
         else:
@@ -300,10 +311,8 @@ def test_graph_sensitivity():
     from mlcolvar.data.graph.utils import create_test_graph_input
 
     for environment in [False, True]:
-        print("\n\n\n\n\n", environment)
         # create data, we need the dataset for sensitivity analysis later
         dataset = create_test_graph_input(output_type='dataset', n_samples=100, n_states=2, n_atoms=3, environment=environment)
-        print(dataset)
         datamodule = DictModule(dataset=dataset, lengths=[0.8, 0.2], shuffle=[1, 0])
 
         # create model
@@ -329,6 +338,3 @@ def test_graph_sensitivity():
 
         # print results
         print(test_sensitivity)
-
-if __name__ == '__main__':
-    test_graph_sensitivity()

--- a/mlcolvar/explain/graph_sensitivity.py
+++ b/mlcolvar/explain/graph_sensitivity.py
@@ -22,6 +22,11 @@ def graph_node_sensitivity(
     partial derivatives w.r.t. nodes' positions. 
     This allows us to measure which atom is most important to the CV model.
 
+    If system/environment atoms are defined in the input dataset, the average node-sensitivities are returned only
+    for the system atom, while a aggregated sensitivities (mean and sum) are returned for environment instead.
+    
+    # TODO xyz?
+
     Parameters
     ----------
     model: mlcolvar.cvs.BaseCV
@@ -38,9 +43,15 @@ def graph_node_sensitivity(
     Returns
     -------
     results: dictionary
-        Results of the sensitivity analysis, containing 'node_indices',
-        'sensitivities', and 'sensitivities_components', ordered according to
-        the node indices.
+        Results of the sensitivity analysis, containing:
+          - 'node_labels': names associated to the nodes of the graphs. If truncated graphs are used, only the system atoms
+                           are labeled, while the contribution from the environment atoms is aggregated with mean and sum.
+          - 'avg_sensitivities': averaged sensititivities over the given dataset. If truncated graphs are used, environment 
+                                 values are aggregated with mean and sum.
+          - 'raw_sensitivities': raw sensitivities per-frame, including the sensitivities relative to each atom. If truncated
+                                 graphs are used, the sensitivities wrt different environment atoms (whose number may change
+                                 for different frame) are returned.
+        The quantities are ordered consistently with the node labels.
 
     See also
     --------
@@ -53,34 +64,44 @@ def graph_node_sensitivity(
                 "The CV model is not based on GNN! Maybe you should use the feedforward sensitivity_analysis from  mlcolvar.utils.explain.sensitivity!"
             )
 
+    # make user aware of behaviour for truncated graphs
+    if dataset.metadata['is_truncated_graph']:
+        print("The input dataset contains truncated graphs for which system and environment selections are provided. the average node-sensitivities" +
+             "will be returned only for the system atom, while an aggregated sensitivty is returned for environment instead")
+
     model = model.to(device)
 
-    gradients = get_dataset_cv_gradients(
-        model=model,
-        dataset=dataset,
-        component=component,
-        batch_size=batch_size,
-        show_progress=show_progress,
-        progress_prefix='Getting gradients'
-    )
-    sensitivities_components = np.linalg.norm(gradients, axis=-1)
-
+    # get gradients of cv model on dataset    
+    gradients_norm, gradients_components = get_dataset_cv_gradients(model=model,
+                                                                    dataset=dataset,
+                                                                    component=component,
+                                                                    batch_size=batch_size,
+                                                                    show_progress=show_progress,
+                                                                    progress_prefix='Getting gradients'
+                                                                    )
+    
+    # create a nice dataset with the results
     results = {}
-    results['atoms_list'] = np.array(dataset.metadata['used_names'])
+    results['atoms_list'] = [a for a in dataset.metadata['system_atoms_names']]
+
+    # append environment result entries if necessary
+    if dataset.metadata['is_truncated_graph']:
+        results['atoms_list'].extend(['environment_atoms_mean', 'environment_atoms_sum'])
+        
     results['node_labels'] = [str(a) for a in results['atoms_list']]
-    # results['node_labels_components'] = np.array([np.array(dataset.metadata['used_names'])[dataset[i]['data_list']['names_idx']] for i in range(len(dataset))])        
-    results['sensitivities'] = sensitivities_components.mean(axis=0)
-    results['sensitivities_components'] = sensitivities_components
+    results['avg_sensitivities'] = gradients_norm
+    results['raw_sensitivities'] = gradients_components
+    
 
     return results
 
-def get_dataset_cv_values(
-    model,
-    dataset,
-    batch_size: int = None,
-    show_progress: bool = True,
-    progress_prefix: str = 'Calculating CV values'
-) -> np.ndarray:
+
+def get_dataset_cv_values(model,
+                          dataset,
+                          batch_size: int = None,
+                          show_progress: bool = True,
+                          progress_prefix: str = 'Calculating CV values'
+                         ) -> np.ndarray:
     """Gets the values of a CV model on a given dataset. 
     The calculation will run on the device where the model is on.
 
@@ -149,17 +170,18 @@ def get_dataset_cv_gradients(
     show_progress: bool
         If to show the progress bar
     """
-    datamodule = DictModule(
-        dataset=dataset,
-        lengths=(1.0,),
-        batch_size=batch_size,
-        random_split=False,
-        shuffle=False
-    )
-    datamodule.setup()
 
-    cv_value_gradients = []
+    # get device
     device = next(model.parameters()).device
+
+    # create a datamodule to initialize the dataloader
+    datamodule = DictModule(dataset=dataset,
+                            lengths=(1.0,),
+                            batch_size=batch_size,
+                            random_split=False,
+                            shuffle=False
+                            )
+    datamodule.setup()
 
     if show_progress:
         items = pbar(
@@ -170,11 +192,20 @@ def get_dataset_cv_gradients(
     else:
         items = datamodule.train_dataloader()
 
+
+    cv_value_gradients = []
+    cv_value_gradients_components = []
+    # iterate over the batches
     for batchs in items:
+        # get data
         batch_dict = batchs['data_list'].to(device)
         batch_dict['positions'].requires_grad_(True)
+        
+        # get desired cv component
         cv_values = model(batch_dict)
         cv_values = cv_values[:, component]
+        
+        # compute gradients
         grad_outputs = [torch.ones_like(cv_values, device=device)]
         gradients = torch.autograd.grad(
             outputs=[cv_values],
@@ -190,16 +221,40 @@ def get_dataset_cv_gradients(
             gradients[0].detach(), graph_sizes.cpu().numpy().tolist()
         )
         
-        # here we ensure that all the gradients have the correct shape 
-        # and that each entry is at the correct index accordingly
-        max_used_atoms = len(dataset.metadata['used_idx'])
-        for i,g in enumerate(gradients):
-            aux = torch.zeros((max_used_atoms, 3))
-            # this populates the right entries according to the orignal indexing
-            aux[batch_dict[i]['names_idx'], :] = g
-            cv_value_gradients.extend(aux.unsqueeze(0).cpu().numpy())
+        if dataset.metadata['is_truncated_graph']:            
+            # here we separate the system (constant in number) and environment (possibly changing) gradients 
+            # system grads are treated individually, env grads are aggragated with sum and mean
+            for i,g in enumerate(gradients):
+                # slice the gradients to get the contribution from system and environment atoms
+                system_atoms_grads = g[batch_dict[i]['system_masks'].squeeze()]
+                env_atoms_grads    = g[torch.logical_not(batch_dict[i]['system_masks'].squeeze())]
 
-    return np.array(cv_value_gradients)
+                # add the values to the result lists
+                # one with the components of the gradients of all atoms, system atoms first
+                cv_value_gradients_components.append(torch.vstack([system_atoms_grads, 
+                                                                   env_atoms_grads
+                                                                  ]).cpu().numpy())
+
+                # one with the norm of the gradients for each system atom and aggregated env atoms
+                cv_value_gradients.extend(torch.concat([torch.linalg.vector_norm(system_atoms_grads, dim=-1),
+                                                        torch.linalg.vector_norm(env_atoms_grads, dim=-1).mean(dim=-1, keepdim=True), 
+                                                        torch.linalg.vector_norm(env_atoms_grads, dim=-1).sum(dim=-1, keepdim=True)
+                                                        ]).unsqueeze(0).cpu().numpy()
+                                        )
+        else:
+            # here we ensure that all the gradients have the correct shape 
+            # and that each entry is at the correct index accordingly
+            max_used_atoms = len(dataset.metadata['system_idx'])
+            for i,g in enumerate(gradients):
+                aux = torch.zeros((max_used_atoms, 3))
+                # this populates the right entries according to the orignal indexing
+                aux[batch_dict[i]['system_names_idx'], :] = g
+                aux = aux.unsqueeze(0)
+                cv_value_gradients.extend(torch.linalg.vector_norm(aux, dim=-1).cpu().numpy())
+                cv_value_gradients_components.extend(aux.cpu().numpy())
+                
+        return cv_value_gradients, cv_value_gradients_components
+
 
 
 def test_get_cv_values_graph():
@@ -244,30 +299,36 @@ def test_graph_sensitivity():
     from mlcolvar.core.nn.graph import SchNetModel
     from mlcolvar.data.graph.utils import create_test_graph_input
 
-    # create data, we need the dataset for sensitivity analysis later
-    dataset = create_test_graph_input(output_type='dataset', n_samples=100, n_states=2, n_atoms=3)
-    datamodule = DictModule(dataset=dataset, lengths=[0.8, 0.2], shuffle=[1, 0])
+    for environment in [False, True]:
+        print("\n\n\n\n\n", environment)
+        # create data, we need the dataset for sensitivity analysis later
+        dataset = create_test_graph_input(output_type='dataset', n_samples=100, n_states=2, n_atoms=3, environment=environment)
+        print(dataset)
+        datamodule = DictModule(dataset=dataset, lengths=[0.8, 0.2], shuffle=[1, 0])
 
-    # create model
-    gnn_model = SchNetModel(n_out=1, cutoff=0.1, atomic_numbers=[8, 1])
-    model = DeepTDA(
-        n_states=2,
-        n_cvs=1,
-        target_centers=[-5, 5],
-        target_sigmas=[0.2, 0.2],
-        model=gnn_model
-    )
+        # create model
+        gnn_model = SchNetModel(n_out=1, cutoff=0.1, atomic_numbers=[8, 1])
+        model = DeepTDA(
+            n_states=2,
+            n_cvs=1,
+            target_centers=[-5, 5],
+            target_sigmas=[0.2, 0.2],
+            model=gnn_model
+        )
 
-    # train model
-    trainer = lightning.Trainer(
-        accelerator="cpu", max_epochs=2, logger=False, enable_checkpointing=False, enable_model_summary=False
-    )
-    trainer.fit(model, datamodule)
+        # train model
+        trainer = lightning.Trainer(
+            accelerator="cpu", max_epochs=2, logger=False, enable_checkpointing=False, enable_model_summary=False
+        )
+        trainer.fit(model, datamodule)
 
-    # do analysis
-    test_sensitivity = graph_node_sensitivity(model=model,
-                                    dataset=dataset,
-                                    batch_size=0)
+        # do analysis
+        test_sensitivity = graph_node_sensitivity(model=model,
+                                        dataset=dataset,
+                                        batch_size=0)
 
-    # print results
-    print(test_sensitivity)
+        # print results
+        print(test_sensitivity)
+
+if __name__ == '__main__':
+    test_graph_sensitivity()

--- a/mlcolvar/utils/io/graphs/ase_.py
+++ b/mlcolvar/utils/io/graphs/ase_.py
@@ -111,7 +111,8 @@ def dataset_from_ase_trajectories(trajectories: List[ase.Atoms],
         
     # get atomic numbers and names from ASE Atoms objects if not provided
     if atom_names is None:
-        atom_names = _names_from_ase_atoms(trajectories)
+        atom_names = _names_from_ase_atoms(ase_atoms_list=trajectories,
+                                           system_selection=system_selection)
 
     # create dataset from configurations list
     dataset = create_dataset_from_configurations(config=configurations,
@@ -299,12 +300,15 @@ def _configurations_from_ase_trajectory(trajectory: ase.Atoms,
     return configurations
 
 
-def _names_from_ase_atoms(ase_atoms_list: List[ase.Atoms]) -> AtomicNumberTable:
+def _names_from_ase_atoms(ase_atoms_list: List[ase.Atoms],
+                          system_selection: Any) -> AtomicNumberTable:
     """Create atomic names from a list of ASE Atoms objects."""
     try:
-        names = ase_atoms_list[0].get_chemical_symbols()
+        indices = _selection_to_indices(system_selection, ase_atoms_list[0])
+        names = ase_atoms_list[0][indices].get_chemical_symbols()
     except AttributeError:
-        names = ase_atoms_list[0][0].get_chemical_symbols()
+        indices = _selection_to_indices(system_selection, ase_atoms_list[0][0])
+        names = ase_atoms_list[0][0][indices].get_chemical_symbols()
 
     return names
 

--- a/mlcolvar/utils/io/graphs/mdtraj_.py
+++ b/mlcolvar/utils/io/graphs/mdtraj_.py
@@ -240,7 +240,6 @@ def _configurations_from_mdtraj_trajectory(trajectory: mdtraj.Trajectory,
         if not set(selected_atoms['subsystem']).issubset(set(selected_atoms['system'])):
             raise ValueError("Only atoms in `system_selection` can be selected by `subsystem_selection`!")
 
-
     # get the list of the atomic numbers for the selected atoms
     atomic_numbers = [a.element.number for a in trajectory.top.atoms]
     
@@ -256,8 +255,8 @@ def _configurations_from_mdtraj_trajectory(trajectory: mdtraj.Trajectory,
     configurations = []
     for i in range(len(trajectory)):
 
-        label_i = _to_torch_tensor(graph_labels[i]).reshape(-1, 1) if graph_labels is not None else None
-        node_i = _to_torch_tensor(node_labels[i]).reshape(-1, 1) if node_labels is not None else None
+        label_i = graph_labels[i].reshape(-1, 1) if graph_labels is not None else None
+        node_i = node_labels[i].reshape(-1, 1) if node_labels is not None else None
 
         configuration = Configuration(atomic_numbers=atomic_numbers,
                                       positions=trajectory.xyz[i] * lengths_conversion,

--- a/mlcolvar/utils/io/graphs/mdtraj_.py
+++ b/mlcolvar/utils/io/graphs/mdtraj_.py
@@ -102,10 +102,9 @@ def dataset_from_mdtraj_trajectories(trajectories: List[mdtraj.Trajectory],
                                                                     atomic_numbers=atomic_numbers)
 
     if atom_names is None:
-        try:
-            atom_names = _names_from_top([trajectory.topology for trajectory in trajectories])
-        except:
-            atom_names = None
+            atom_names = _names_from_top(top= [trajectory.topology for trajectory in trajectories],
+                                         system_selection=system_selection)
+
     
 
     # create dataset from configurations list
@@ -286,15 +285,19 @@ def _atomic_numbers_from_top(top: List[mdtraj.Topology]) -> AtomicNumberTable:
     return atomic_numbers
 
 
-def _names_from_top(top: List[mdtraj.Topology] ) -> List[str]:
+def _names_from_top(top: List[mdtraj.Topology],
+                    system_selection: str) -> List[str]:
     """Retrieve atom names from the topologies."""
+    
+    # apply selection
+    top = [t.subset(t.select(system_selection)) for t in top]
 
     it = iter(top)
     atom_names = list(next(it).atoms)
     if not all([atom_names == list(n.atoms) for n in it]):
         raise ValueError("The atoms names or their order are different in the topology files. Check or deactivate save_names")
-    
     return atom_names
+
 
 def _get_required_atoms_selection(system_selection : str,
                                   environment_selection : str) -> str:

--- a/mlcolvar/utils/io/graphs/mdtraj_.py
+++ b/mlcolvar/utils/io/graphs/mdtraj_.py
@@ -102,8 +102,8 @@ def dataset_from_mdtraj_trajectories(trajectories: List[mdtraj.Trajectory],
                                                                     atomic_numbers=atomic_numbers)
 
     if atom_names is None:
-            atom_names = _names_from_top(top= [trajectory.topology for trajectory in trajectories],
-                                         system_selection=system_selection)
+        atom_names = _names_from_top(top= [trajectory.topology for trajectory in trajectories],
+                                     system_selection=system_selection)
 
     
 
@@ -289,6 +289,9 @@ def _names_from_top(top: List[mdtraj.Topology],
                     system_selection: str) -> List[str]:
     """Retrieve atom names from the topologies."""
     
+    if system_selection is None:
+        system_selection = 'all'
+
     # apply selection
     top = [t.subset(t.select(system_selection)) for t in top]
 

--- a/mlcolvar/utils/timelagged.py
+++ b/mlcolvar/utils/timelagged.py
@@ -407,9 +407,9 @@ def create_timelagged_dataset(
                                               "cutoff" :            X.metadata["cutoff"],
                                               "buffer":             X.metadata["buffer"],
                                               "long_range_cutoff":  X.metadata["long_range_cutoff"],
-                                              "system_idx":         X.metadata["unique_idx"],
-                                              "system_atoms_names": X.metadata["unique_names"],
-                                              "is_truncated_graph": X.metadata["truncated"]
+                                              "system_idx":         X.metadata["system_idx"],
+                                              "system_atoms_names": X.metadata["system_atoms_names"],
+                                              "is_truncated_graph": X.metadata["is_truncated_graph"]
                                               },
                                     data_type="graphs")
             # update weights

--- a/mlcolvar/utils/timelagged.py
+++ b/mlcolvar/utils/timelagged.py
@@ -401,11 +401,16 @@ def create_timelagged_dataset(
         elif X.metadata["data_type"] == "graphs":
             # we use deepcopy to avoid editing the original dataset
             atomic_numbers = X.metadata.get("atomic_numbers", None)
-            dataset = DictDataset(dictionary={"data_list" : copy.deepcopy(X[x_t.numpy().tolist()]["data_list"]),
-                                            "data_list_lag" : copy.deepcopy(X[x_lag.numpy().tolist()]["data_list"])},
-                                    metadata={"atomic_numbers" : atomic_numbers,
-                                            "cutoff" : X.metadata["cutoff"],
-                                            "long_range_cutoff": X.metadata["long_range_cutoff"]},
+            dataset = DictDataset(dictionary={"data_list" :     copy.deepcopy(X[x_t.numpy().tolist()]["data_list"]),
+                                              "data_list_lag" : copy.deepcopy(X[x_lag.numpy().tolist()]["data_list"])},
+                                    metadata={"atomic_numbers" :    atomic_numbers,
+                                              "cutoff" :            X.metadata["cutoff"],
+                                              "buffer":             X.metadata["buffer"],
+                                              "long_range_cutoff":  X.metadata["long_range_cutoff"],
+                                              "system_idx":         X.metadata["unique_idx"],
+                                              "system_atoms_names": X.metadata["unique_names"],
+                                              "is_truncated_graph": X.metadata["truncated"]
+                                              },
                                     data_type="graphs")
             # update weights
             for i in range(len(dataset)):


### PR DESCRIPTION
## Description
This PR introduces graph node sensitivty for truncated graphs.
When using truncated graphs, the average values are returned for each system atom while for enfvironment atoms only aggregated results are reported (mean and sum over the contributions).
Per-frame and per-atom raw senstitivities are also returned.
Optionally, the per-atom sensitivities can also be printed to an xyz file for easier visualization in an external molecular viewer.

This required a few modifications in the dataset.metadata for graph datasets.

## Questions
- [x] Is it worth it to save the sensitivity norms to xyz file? 

## Status
- [x] Ready to go