### PR TITLE
ci: work around PyTorch MPS issues on macOS

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,15 +21,11 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    # macOS CI temporarily disabled due to a PyTorch MPS/Metal issue.
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]      
         python-version: ["3.11", "3.12", "3.13"]
-        include:
-          - python-version: "3.11"
-            os: macos-latest
-          - python-version: "3.12"
-            os: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -40,13 +36,6 @@ jobs:
           uname -a
           df -h
           ulimit -a
-      # this may be removed in the future when MPS issues will be solved in all torch versions
-      # check https://github.com/pytorch/pytorch/issues/77764
-      - name: Add MPS fallback [macOS only]
-        if: contains( matrix.os, 'macOS' )
-        shell: bash
-        run: |
-          echo "PYTORCH_ENABLE_MPS_FALLBACK=1" >> $GITHUB_ENV     
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,7 +43,7 @@ jobs:
       # this may be removed in the future when MPS issues will be solved in all torch versions
       # check https://github.com/pytorch/pytorch/issues/77764
       - name: Add MPS fallback [macOS only]
-        if: contains( matrix.os, 'macOS' )
+        if: contains( matrix.os, 'macos' )
         shell: bash
         run: |
           echo "PYTORCH_ENABLE_MPS_FALLBACK=1" >> $GITHUB_ENV     
@@ -52,22 +52,29 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Check Python
+        shell: bash
+        run: |
+          which python
+          python --version
+          python -c "import sys; print(sys.executable)"
       
       - name: Upgrade pip
         run: python -m pip install -U pip
 
       - name: Install package
         # conda setup requires this special shell
-        shell: bash -l {0}
+        shell: bash
         run: |
           python -m pip install -e .[test]
-          pip list
+          python -m pip list
 
       - name: Run tests
         # conda setup requires this special shell
-        shell: bash -l {0}
+        shell: bash
         run: |
-          pytest -v --pyargs mlcolvar.tests --cov=mlcolvar --cov-report=xml --color=yes
+          python -m pytest -v --pyargs mlcolvar.tests --cov=mlcolvar --cov-report=xml --color=yes
 
       - name: Run notebook tests
         # conda setup requires this special shell

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,15 +21,11 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    # macOS CI temporarily disabled due to a PyTorch MPS/Metal issue.
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]      
         python-version: ["3.11", "3.12", "3.13"]
-        include:
-          - python-version: "3.11"
-            os: macos-latest
-          - python-version: "3.12"
-            os: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -40,41 +36,27 @@ jobs:
           uname -a
           df -h
           ulimit -a
-      # this may be removed in the future when MPS issues will be solved in all torch versions
-      # check https://github.com/pytorch/pytorch/issues/77764
-      - name: Add MPS fallback [macOS only]
-        if: contains( matrix.os, 'macos' )
-        shell: bash
-        run: |
-          echo "PYTORCH_ENABLE_MPS_FALLBACK=1" >> $GITHUB_ENV     
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Check Python
-        shell: bash
-        run: |
-          which python
-          python --version
-          python -c "import sys; print(sys.executable)"
       
       - name: Upgrade pip
         run: python -m pip install -U pip
 
       - name: Install package
         # conda setup requires this special shell
-        shell: bash
+        shell: bash -l {0}
         run: |
           python -m pip install -e .[test]
-          python -m pip list
+          pip list
 
       - name: Run tests
         # conda setup requires this special shell
-        shell: bash
+        shell: bash -l {0}
         run: |
-          python -m pytest -v --pyargs mlcolvar.tests --cov=mlcolvar --cov-report=xml --color=yes
+          pytest -v --pyargs mlcolvar.tests --cov=mlcolvar --cov-report=xml --color=yes
 
       - name: Run notebook tests
         # conda setup requires this special shell

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,11 +21,15 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    # macOS CI temporarily disabled due to a PyTorch MPS/Metal issue.
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]      
         python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - python-version: "3.11"
+            os: macos-latest
+          - python-version: "3.12"
+            os: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +40,13 @@ jobs:
           uname -a
           df -h
           ulimit -a
+      # this may be removed in the future when MPS issues will be solved in all torch versions
+      # check https://github.com/pytorch/pytorch/issues/77764
+      - name: Add MPS fallback [macOS only]
+        if: contains( matrix.os, 'macOS' )
+        shell: bash
+        run: |
+          echo "PYTORCH_ENABLE_MPS_FALLBACK=1" >> $GITHUB_ENV     
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/mlcolvar/cvs/cv.py
+++ b/mlcolvar/cvs/cv.py
@@ -1,6 +1,3 @@
-import platform
-import warnings
-
 import torch
 from mlcolvar.core.transform import Transform
 
@@ -69,17 +66,6 @@ class BaseCV:
             or not hasattr(self.preprocessing, "in_features")
             else self.preprocessing.in_features
         )
-        
-    def to_torchscript(self, file_path=None, *args, **kwargs):
-        if file_path is not None and platform.system() == "Darwin":
-            warnings.warn(
-                "Saving TorchScript models on macOS may be affected by "
-                "a temporary PyTorch MPS/Metal issue.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-
-        return super().to_torchscript(file_path, *args, **kwargs)
 
     def parse_options(self, options: dict = None):
         """

--- a/mlcolvar/cvs/cv.py
+++ b/mlcolvar/cvs/cv.py
@@ -1,3 +1,6 @@
+import platform
+import warnings
+
 import torch
 from mlcolvar.core.transform import Transform
 
@@ -66,6 +69,17 @@ class BaseCV:
             or not hasattr(self.preprocessing, "in_features")
             else self.preprocessing.in_features
         )
+        
+    def to_torchscript(self, file_path=None, *args, **kwargs):
+        if file_path is not None and platform.system() == "Darwin":
+            warnings.warn(
+                "Saving TorchScript models on macOS may be affected by "
+                "a temporary PyTorch MPS/Metal issue.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        return super().to_torchscript(file_path, *args, **kwargs)
 
     def parse_options(self, options: dict = None):
         """


### PR DESCRIPTION
## Description
This PR adds a temporary workaround for the current PyTorch MPS/Metal issues on macOS.

The macOS CI currently fails in linear algebra operations such as `torch.linalg.cholesky`, affecting DeepLDA, DeepTICA, SelfTICA, and related tests.

## Changes

- Temporarily disable the macOS CI jobs.
- Add a warning when saving TorchScript models on macOS.

## Notes

This is intended as a temporary workaround and can be removed once the upstream PyTorch MPS issue is resolved.

## Status
- [ ] Ready to go