### PR TITLE
ci: pin PyTorch 2.13 for PLUMED tests

### DIFF
--- a/.github/workflows/plumed.yaml
+++ b/.github/workflows/plumed.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Install package
         run: |
+          python -m pip install "torch==2.13.0"
           python -m pip install -e .[test]
 
       - name: Configure libtorch flags


### PR DESCRIPTION
## Description
The PLUMED CI started failing after PyTorch was upgraded from 2.13.0 to 2.14.0.
With PyTorch 2.14.0, PLUMED 2.10.0 does not successfully enable LibTorch, and
`plumed config has libtorch` returns `libtorch off`.

This PR pins PyTorch to 2.13.0 only in the PLUMED integration workflow as a
temporary workaround.

## Status
- [ ] Ready to go